### PR TITLE
Trigger obfuscation only when it's necessary

### DIFF
--- a/app/controllers/api/v1/lab_record_imports_controller.rb
+++ b/app/controllers/api/v1/lab_record_imports_controller.rb
@@ -5,10 +5,11 @@ module Api
         lab_record_import = build_lab_record_import
 
         if lab_record_import.save
-          InsertLabRecordsWorker.perform_async(
+          InsertLabRecordsWorker.perform_async( # rubocop:disable Style/MultilineIfModifier
             lab_record_import.id,
             params[:lab_records_attributes]
-          )
+          ) unless lab_record_import.skip_obfuscation?
+
           render json: {
             id: lab_record_import.id,
             created_at: lab_record_import.created_at,
@@ -36,7 +37,7 @@ module Api
 
       def build_lab_record_import
         lab_record_import = LabRecordImport.create(permitted_params)
-        lab_record_import.patient_id_state = :pending
+        lab_record_import.patient_id_state = lab_record_import.skip_obfuscation? ? 'obfuscated' : 'pending' # rubocop:disable Metrics/LineLength
         lab_record_import
       end
 

--- a/app/models/lab_record_import.rb
+++ b/app/models/lab_record_import.rb
@@ -40,4 +40,8 @@ class LabRecordImport < ApplicationRecord
   def patient_id_index
     patient_or_lab_record_id.index('patientId').to_i
   end
+
+  def skip_obfuscation?
+    patient_or_lab_record_id.empty? || phi.empty?
+  end
 end


### PR DESCRIPTION
Closes instedd/maap-collector/issues/270

Changes introduced in instedd/maap-collector/commit/c67fb031f0df1e59b0615ac23043ee7200d600a3
allows to upload a lab record import without using the obfuscation capabilities.
This kind of imports are now considered specially at server side.

Columns that contains obfuscation information are sent as empty arrays whenever
obfuscation capabilities are turned-off, so that is the condition being checked
in the `skip_obfuscation?` function.