### PR TITLE
Check skip_obfuscation? condition on each step

### DIFF
--- a/app/controllers/api/v1/lab_record_imports_controller.rb
+++ b/app/controllers/api/v1/lab_record_imports_controller.rb
@@ -5,10 +5,10 @@ module Api
         lab_record_import = build_lab_record_import
 
         if lab_record_import.save
-          InsertLabRecordsWorker.perform_async( # rubocop:disable Style/MultilineIfModifier
+          InsertLabRecordsWorker.perform_async(
             lab_record_import.id,
             params[:lab_records_attributes]
-          ) unless lab_record_import.skip_obfuscation?
+          )
 
           render json: {
             id: lab_record_import.id,
@@ -37,7 +37,7 @@ module Api
 
       def build_lab_record_import
         lab_record_import = LabRecordImport.create(permitted_params)
-        lab_record_import.patient_id_state = lab_record_import.skip_obfuscation? ? 'obfuscated' : 'pending' # rubocop:disable Metrics/LineLength
+        lab_record_import.patient_id_state = :pending
         lab_record_import
       end
 

--- a/app/interactors/anonymize_lab_record_import/obfuscate_patient_ids.rb
+++ b/app/interactors/anonymize_lab_record_import/obfuscate_patient_ids.rb
@@ -5,7 +5,7 @@ module AnonymizeLabRecordImport
     include Interactor
 
     def call # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      return unless context.patient_ids
+      return if !context.patient_ids || context.record.skip_obfuscation?
 
       header_cell =
         read_cell(

--- a/app/interactors/sheets/prune_table_fields.rb
+++ b/app/interactors/sheets/prune_table_fields.rb
@@ -12,7 +12,7 @@ module Sheets
     private
 
     def send_to_obfuscated_state!
-      context.record[context.state_attribute] = :obfuscated if context.obfuscate_on_finish
+      context.record[context.state_attribute] = :obfuscated if context.obfuscate_on_finish || context.record.skip_obfuscation? # rubocop:disable Metrics/LineLength
     end
   end
 end

--- a/app/interactors/sheets/remove_fields.rb
+++ b/app/interactors/sheets/remove_fields.rb
@@ -21,7 +21,7 @@ module Sheets
     }.freeze
 
     def call # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-      return if context.patient_ids
+      return if context.patient_ids || context.record.skip_obfuscation?
 
       (first_row..last_row).to_a.each do |row_number|
         columns_to_offuscate.each do |column_number|

--- a/app/workers/insert_lab_records_worker.rb
+++ b/app/workers/insert_lab_records_worker.rb
@@ -15,7 +15,9 @@ class InsertLabRecordsWorker
     JSON[@lab_records]
   end
 
-  def import_lab_records
+  def import_lab_records # rubocop:disable Metrics/AbcSize
+    return if lab_record_import.skip_obfuscation?
+
     parsed_records.each do |lab_record_attributes|
       lab_record = LabRecord.new(lab_record_attributes)
       lab_record.site = lab_record_import.site


### PR DESCRIPTION
For instedd/maap-collector/issues/295

Previous approach for skipping obfuscation wasn't considering
that some steps have to be performed regardless of obfuscating
the file or not (i.e renaming the file and uploading to S3).

New solution involves checking the condition
on each step, so necessary transformations can be performed.