### PR TITLE
Stop running migrations on `workers` up

### DIFF
--- a/bin/app_update
+++ b/bin/app_update
@@ -19,7 +19,7 @@ chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
 
   puts "\n== Updating database =="
-  system! 'bin/rails db:migrate || bin/rails db:setup'
+  system! 'bin/rails db:migrate || (bin/rails db:create && bin/rails db:schema:load && bin/rails db:seed)'
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'

--- a/bin/workers_update
+++ b/bin/workers_update
@@ -17,13 +17,4 @@ chdir APP_ROOT do
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
-
-  puts "\n== Updating database =="
-  system! 'bin/rails db:migrate || bin/rails db:setup'
-
-  puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
-
-  puts "\n== Removing assets =="
-  system! 'bin/rails assets:clobber'
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     build: 
       context: .
       dockerfile: Dockerfile-dev
+    depends_on:
+      - db
     links:
       - db
       - cache
@@ -22,6 +24,8 @@ services:
     build: 
       context: .
       dockerfile: Dockerfile-dev
+    depends_on:
+      - app
     links:
       - db
       - cache


### PR DESCRIPTION
For https://github.com/instedd/maap-collector/issues/324

Also, adds dependencies between containers in `docker-compose.yml`

I had to split `db:setup` into `db:create`, `schema:load` and `db:seed` because for some reason that I don't understand it was failing at seeding the data the previous way